### PR TITLE
[WIP] use grpc standard health check in python client

### DIFF
--- a/client/fossildb-client
+++ b/client/fossildb-client
@@ -13,12 +13,11 @@ from grpc_health.v1 import health_pb2_grpc
 def main():
 
     commands = {
-        'backup': lambda stub, healthStub:
+        'backup': lambda stub:
             stub.Backup(proto.BackupRequest()),
-        'restore': lambda stub, healthStub:
+        'restore': lambda stub:
             stub.RestoreFromBackup(proto.RestoreFromBackupRequest()),
-        'health': lambda stub, healthStub:
-            healthStub.Check(health_pb2.HealthCheckRequest(service=''))
+        'health': None
     }
 
     parser = argparse.ArgumentParser()
@@ -47,11 +46,25 @@ def main():
     stub = proto_rpc.FossilDBStub(channel)
     healthStub = health_pb2_grpc.HealthStub(channel)
 
-    reply = commands[args.command](stub, healthStub)
+    if args.command == 'health':
+        try :
+            reply = healthStub.Check(health_pb2.HealthCheckRequest(service=''))
+            print(reply)
+            UNKNOWN = 0;
+            SERVING = 1;
+            NOT_SERVING = 2;
+            if reply.status != SERVING:
+                raise Exception(reply.status)
+        except Exception as e:
+            print('Health check unsuccessful. FossilDB offline?')
+            print(e)
+            sys.exit(1)
 
-    print(reply)
-    if not reply.success:
-        sys.exit(1)
+    else:
+        reply = commands[args.command](stub)
+        print(reply)
+        if not reply.success:
+            sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/client/fossildb-client
+++ b/client/fossildb-client
@@ -7,16 +7,18 @@ import sys
 import fossildbapi_pb2 as proto
 import fossildbapi_pb2_grpc as proto_rpc
 
+from grpc_health.v1 import health_pb2
+from grpc_health.v1 import health_pb2_grpc
 
 def main():
 
     commands = {
-        'backup': lambda stub:
+        'backup': lambda stub, healthStub:
             stub.Backup(proto.BackupRequest()),
-        'restore': lambda stub:
+        'restore': lambda stub, healthStub:
             stub.RestoreFromBackup(proto.RestoreFromBackupRequest()),
-        'health': lambda stub:
-            stub.Health(proto.HealthRequest())
+        'health': lambda stub, healthStub:
+            healthStub.Check(health_pb2.HealthCheckRequest(service=''))
     }
 
     parser = argparse.ArgumentParser()
@@ -43,8 +45,9 @@ def main():
 
     channel = grpc.insecure_channel(full_address)
     stub = proto_rpc.FossilDBStub(channel)
+    healthStub = health_pb2_grpc.HealthStub(channel)
 
-    reply = commands[args.command](stub)
+    reply = commands[args.command](stub, healthStub)
 
     print(reply)
     if not reply.success:

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,2 +1,3 @@
 argparse
 grpcio-tools
+grpcio-health-checking


### PR DESCRIPTION
@jstriebel I’m not really satisfied with the lambda solution anymore, since the method now uses the two stubs. Also, 
```
    if not reply.success:
        sys.exit(1)
```
doesn’t work anymore since HealthCheckReply does not have a success field.
Do you have any ideas / opinions?

fixes #22