### PR TITLE
Fix column family options

### DIFF
--- a/src/main/protobuf/fossildbapi.proto
+++ b/src/main/protobuf/fossildbapi.proto
@@ -130,6 +130,13 @@ message RestoreFromBackupReply {
     optional string errorMessage = 2;
 }
 
+message CompactAllDataRequest {}
+
+message CompactAllDataReply {
+    required bool success = 1;
+    optional string errorMessage = 2;
+}
+
 
 service FossilDB {
     rpc Health (HealthRequest) returns (HealthReply) {}
@@ -143,4 +150,5 @@ service FossilDB {
     rpc ListVersions (ListVersionsRequest) returns (ListVersionsReply) {}
     rpc Backup (BackupRequest) returns (BackupReply) {}
     rpc RestoreFromBackup (RestoreFromBackupRequest) returns (RestoreFromBackupReply) {}
+    rpc CompactAllData (CompactAllDataRequest) returns (CompactAllDataReply) {}
 }

--- a/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
+++ b/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
@@ -90,6 +90,10 @@ class FossilDBGrpcImpl(storeManager: StoreManager)
     RestoreFromBackupReply(true)
   } {errorMsg => RestoreFromBackupReply(false, errorMsg)}
 
+  override def compactAllData(req: CompactAllDataRequest) = withExceptionHandler(req) {
+    storeManager.compactAllData
+    CompactAllDataReply(true)
+  } {errorMsg => CompactAllDataReply(false, errorMsg)}
 
   private def withExceptionHandler [T, R <: GeneratedMessage](request: R)(tryBlock: => T)(onErrorBlock: Option[String] => T): Future[T] = {
     try {

--- a/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
@@ -35,7 +35,7 @@ class RocksDBManager(dataDir: Path, columnFamilies: List[String], optionsFilePat
     }
     options.setCreateIfMissing(true).setCreateMissingColumnFamilies(true)
     val defaultColumnFamilyOptions = cfListRef.find(_.getName sameElements RocksDB.DEFAULT_COLUMN_FAMILY).map(_.getOptions).getOrElse(new ColumnFamilyOptions())
-    val newColumnFamilyDescriptors = columnFamilies.map(_.getBytes).diff(cfListRef.toList.map(_.getName)).map(new ColumnFamilyDescriptor(_, defaultColumnFamilyOptions))
+    val newColumnFamilyDescriptors = (columnFamilies.map(_.getBytes) :+ RocksDB.DEFAULT_COLUMN_FAMILY).diff(cfListRef.toList.map(_.getName)).map(new ColumnFamilyDescriptor(_, defaultColumnFamilyOptions))
     val columnFamilyDescriptors = cfListRef.toList ::: newColumnFamilyDescriptors
     logger.info("Opening RocksDB at " + dataDir.toAbsolutePath)
     val columnFamilyHandles = new util.ArrayList[ColumnFamilyHandle]

--- a/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
@@ -21,7 +21,7 @@ class RocksDBManager(dataDir: Path, columnFamilies: List[String], optionsFilePat
 
   val (db: RocksDB, columnFamilyHandles) = {
     RocksDB.loadLibrary()
-    val options = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true)
+    val options = new DBOptions()
     val cfListRef: mutable.Buffer[ColumnFamilyDescriptor] = mutable.Buffer()
     optionsFilePathOpt.foreach { optionsFilePath =>
       try {
@@ -33,6 +33,7 @@ class RocksDBManager(dataDir: Path, columnFamilies: List[String], optionsFilePat
         }
       }
     }
+    options.setCreateIfMissing(true).setCreateMissingColumnFamilies(true)
     val newColumnFamilyDescriptors = (columnFamilies.map(_.getBytes) :+ RocksDB.DEFAULT_COLUMN_FAMILY).diff(cfListRef.toList.map(_.getName)).map(new ColumnFamilyDescriptor(_))
     val columnFamilyDescriptors = cfListRef.toList ::: newColumnFamilyDescriptors
     logger.info("Opening RocksDB at " + dataDir.toAbsolutePath)

--- a/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
@@ -71,6 +71,13 @@ class RocksDBManager(dataDir: Path, columnFamilies: List[String], optionsFilePat
     logger.info("Restoring from backup complete. Reopening RocksDB")
   }
 
+  def compactAllData() = {
+    logger.info("Compacting all data")
+    RocksDB.loadLibrary()
+    db.compactRange()
+    logger.info("All data has been compacted to last level containing data")
+  }
+
   def close(): Future[Unit] = {
     logger.info("Closing RocksDB handle")
     Future.successful(db.close())

--- a/src/main/scala/com/scalableminds/fossildb/db/StoreManager.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/StoreManager.scala
@@ -66,6 +66,14 @@ class StoreManager(dataDir: Path, backupDir: Path, columnFamilies: List[String],
     }
   }
 
+  def compactAllData = {
+    failDuringBackup
+    failDuringRestore
+    try {
+      rocksDBManager.get.compactAllData()
+    }
+  }
+
   def close = {
     rocksDBManager.map(_.close)
   }


### PR DESCRIPTION
don’t overwrite rocksdb defaults (except for create if missing) – to tune fossildb to your server, create a rocksdb config file