### PR TITLE
Fix Integer Overflow in Default Column Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           key: cache-{{ .Branch }}
       - run:
           name: Build server
-          command: docker-compose run -e CI=$CI sbt sbt assembly
+          command: docker-compose run -T -e CI=$CI sbt sbt assembly
       - run:
           name: Get FossilDB version
           command: docker-compose run sbt java -jar $TARGET_DIR/fossildb.jar --version > $TARGET_DIR/version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
       image: ubuntu-2004:202111-02
     environment:
       SBT_VERSION_TAG: sbt-0.13.15_mongo-3.2.17_node-8.x_jdk-8
-      USER_UID: 1001
-      USER_GID: 1001
+      USER_UID: 1000
+      USER_GID: 1000
       TARGET_DIR: target/scala-2.12
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_and_push:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     environment:
       SBT_VERSION_TAG: sbt-0.13.15_mongo-3.2.17_node-8.x_jdk-8
       USER_UID: 1001

--- a/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
@@ -3,13 +3,11 @@
  */
 package com.scalableminds.fossildb.db
 
-import java.io.File
-import java.nio.file.{Files, Path, Paths}
-import java.util
-
 import com.typesafe.scalalogging.LazyLogging
 import org.rocksdb._
 
+import java.nio.file.{Files, Path}
+import java.util
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -23,9 +21,9 @@ class RocksDBManager(dataDir: Path, columnFamilies: List[String], optionsFilePat
   val (db: RocksDB, columnFamilyHandles) = {
     RocksDB.loadLibrary()
     val columnOptions = new ColumnFamilyOptions()
-      .setArenaBlockSize(4 * 1024 * 1024) // 4MB
-      .setTargetFileSizeBase(1024 * 1024 * 1024) // 1GB
-      .setMaxBytesForLevelBase(10 * 1024 * 1024 * 1024) // 10GB
+      .setArenaBlockSize(4L * 1024 * 1024) // 4MB
+      .setTargetFileSizeBase(1024L * 1024 * 1024) // 1GB
+      .setMaxBytesForLevelBase(10L * 1024 * 1024 * 1024) // 10GB
     val options = new DBOptions()
     val cfListRef: mutable.Buffer[ColumnFamilyDescriptor] = mutable.Buffer()
     optionsFilePathOpt.foreach { optionsFilePath =>


### PR DESCRIPTION
Turns out `10 * 1024 * 1024 * 1024` is `-2147483648` :facepalm: (which then rocksdb turns into `18446744071562067968`) when what we wanted for the config option MaxBytesForLevelBase was `10737418240`

I do not know why the CI is not running, maybe the circleci config is outdated? Cannot clone the repository?