### PR TITLE
Sort versions in interactive client

### DIFF
--- a/client/interactive/client.py
+++ b/client/interactive/client.py
@@ -67,6 +67,7 @@ class KeyInfoWidget(Widget):
 
         try:
             self.versions = listVersions(stub, self.collection, key)
+            self.versions.sort()
             log.write(Text("Versions:", style="bold magenta"))
             log.write(",".join(map(str, self.versions)))
             self.key_save_filename = self.sanitize_filename(


### PR DESCRIPTION
Versions were in arbitrary order, which made debugging harder. Now versions are sorted so that the latest version can be downloaded.