### PR TITLE
Close all RocksIterators

### DIFF
--- a/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
+++ b/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
@@ -2,22 +2,15 @@ package com.scalableminds.fossildb
 
 import java.io.{PrintWriter, StringWriter}
 import com.google.protobuf.ByteString
-import com.scalableminds.fossildb.db.{StoreManager, VersionedKeyValueStore}
+import com.scalableminds.fossildb.db.StoreManager
 import com.scalableminds.fossildb.proto.fossildbapi._
 import scalapb.GeneratedMessage
 import com.typesafe.scalalogging.LazyLogging
-import org.rocksdb.RocksIterator
 
 import scala.concurrent.Future
 
-trait RawIteratorHelper {
-
-
-}
-
 class FossilDBGrpcImpl(storeManager: StoreManager)
   extends FossilDBGrpc.FossilDB
-    with RawIteratorHelper
     with LazyLogging {
 
   override def health(req: HealthRequest): Future[HealthReply] = withExceptionHandler(req) {

--- a/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
+++ b/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
@@ -19,7 +19,7 @@ class FossilDBGrpcImpl(storeManager: StoreManager)
 
   override def get(req: GetRequest): Future[GetReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
-    val versionedKeyValuePairOpt = store.withRawRocksIterator{rawIt => store.get(rawIt, req.key, req.version)}
+    val versionedKeyValuePairOpt = store.withRawRocksIterator{rocksIt => store.get(rocksIt, req.key, req.version)}
     versionedKeyValuePairOpt match {
       case Some(pair) => GetReply(success = true, None, ByteString.copyFrom(pair.value), pair.version)
       case None =>
@@ -30,7 +30,7 @@ class FossilDBGrpcImpl(storeManager: StoreManager)
 
   override def put(req: PutRequest): Future[PutReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
-    val version = store.withRawRocksIterator{rawIt => req.version.getOrElse(store.get(rawIt, req.key, None).map(_.version + 1).getOrElse(0L))}
+    val version = store.withRawRocksIterator{rocksIt => req.version.getOrElse(store.get(rocksIt, req.key, None).map(_.version + 1).getOrElse(0L))}
     require(version >= 0, "Version numbers must be non-negative")
     store.put(req.key, version, req.value.toByteArray)
     PutReply(success = true)
@@ -44,31 +44,31 @@ class FossilDBGrpcImpl(storeManager: StoreManager)
 
   override def getMultipleVersions(req: GetMultipleVersionsRequest): Future[GetMultipleVersionsReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
-    val (values, versions) = store.withRawRocksIterator{rawIt => store.getMultipleVersions(rawIt, req.key, req.oldestVersion, req.newestVersion)}
+    val (values, versions) = store.withRawRocksIterator{rocksIt => store.getMultipleVersions(rocksIt, req.key, req.oldestVersion, req.newestVersion)}
     GetMultipleVersionsReply(success = true, None, values.map(ByteString.copyFrom), versions)
   } { errorMsg => GetMultipleVersionsReply(success = false, errorMsg) }
 
   override def getMultipleKeys(req: GetMultipleKeysRequest): Future[GetMultipleKeysReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
-    val (keys, values, versions) = store.withRawRocksIterator{rawIt => store.getMultipleKeys(rawIt, req.startAfterKey, req.prefix, req.version, req.limit)}
+    val (keys, values, versions) = store.withRawRocksIterator{rocksIt => store.getMultipleKeys(rocksIt, req.startAfterKey, req.prefix, req.version, req.limit)}
     GetMultipleKeysReply(success = true, None, keys, values.map(ByteString.copyFrom), versions)
   } { errorMsg => GetMultipleKeysReply(success = false, errorMsg) }
 
   override def deleteMultipleVersions(req: DeleteMultipleVersionsRequest): Future[DeleteMultipleVersionsReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
-    store.withRawRocksIterator{rawIt => store.deleteMultipleVersions(rawIt, req.key, req.oldestVersion, req.newestVersion)}
+    store.withRawRocksIterator{rocksIt => store.deleteMultipleVersions(rocksIt, req.key, req.oldestVersion, req.newestVersion)}
     DeleteMultipleVersionsReply(success = true)
   } { errorMsg => DeleteMultipleVersionsReply(success = false, errorMsg) }
 
   override def listKeys(req: ListKeysRequest): Future[ListKeysReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
-    val keys = store.withRawRocksIterator{rawIt => store.listKeys(rawIt, req.limit, req.startAfterKey)}
+    val keys = store.withRawRocksIterator{rocksIt => store.listKeys(rocksIt, req.limit, req.startAfterKey)}
     ListKeysReply(success = true, None, keys)
   } { errorMsg => ListKeysReply(success = false, errorMsg) }
 
   override def listVersions(req: ListVersionsRequest): Future[ListVersionsReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
-    val versions = store.withRawRocksIterator{rawIt => store.listVersions(rawIt, req.key, req.limit, req.offset)}
+    val versions = store.withRawRocksIterator{rocksIt => store.listVersions(rocksIt, req.key, req.limit, req.offset)}
     ListVersionsReply(success = true, None, versions)
   } { errorMsg => ListVersionsReply(success = false, errorMsg) }
 

--- a/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
@@ -86,8 +86,8 @@ class RocksDBManager(dataDir: Path, columnFamilies: List[String], optionsFilePat
     val newManager = new RocksDBManager(newDataDir, columnFamilies, newOptionsFilePathOpt)
     newManager.columnFamilyHandles.foreach { case (name, handle) =>
       val store = getStoreForColumnFamily(name).get
-      store.withRawRocksIterator { rawIt =>
-        val dataIterator = RocksDBStore.scan(rawIt, "", None)
+      store.withRawRocksIterator { rocksIt =>
+        val dataIterator = RocksDBStore.scan(rocksIt, "", None)
         dataIterator.foreach(el => newManager.db.put(handle, el.key.getBytes, el.value))
       }
     }
@@ -133,11 +133,11 @@ class RocksDBIterator(it: RocksIterator, prefix: Option[String]) extends Iterato
 class RocksDBStore(db: RocksDB, handle: ColumnFamilyHandle) extends LazyLogging {
 
   def withRawRocksIterator[T](block: RocksIterator => T): T = {
-    val rawIt = db.newIterator(handle)
+    val rocksIt = db.newIterator(handle)
     try {
-      block(rawIt)
+      block(rocksIt)
     } finally {
-      rawIt.close()
+      rocksIt.close()
     }
   }
 
@@ -157,14 +157,14 @@ class RocksDBStore(db: RocksDB, handle: ColumnFamilyHandle) extends LazyLogging 
 
 object RocksDBStore {
 
-  def scan(it: RocksIterator, key: String, prefix: Option[String]): RocksDBIterator = {
-    it.seek(key.getBytes())
-    new RocksDBIterator(it, prefix)
+  def scan(rocksIt: RocksIterator, key: String, prefix: Option[String]): RocksDBIterator = {
+    rocksIt.seek(key.getBytes())
+    new RocksDBIterator(rocksIt, prefix)
   }
 
-  def scanKeysOnly(it: RocksIterator, key: String, prefix: Option[String]): RocksDBKeyIterator = {
-    it.seek(key.getBytes())
-    new RocksDBKeyIterator(it, prefix)
+  def scanKeysOnly(rocksIt: RocksIterator, key: String, prefix: Option[String]): RocksDBKeyIterator = {
+    rocksIt.seek(key.getBytes())
+    new RocksDBKeyIterator(rocksIt, prefix)
   }
 
 }

--- a/src/main/scala/com/scalableminds/fossildb/db/VersionedKeyValueStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/VersionedKeyValueStore.scala
@@ -1,5 +1,7 @@
 package com.scalableminds.fossildb.db
 
+import org.rocksdb.RocksIterator
+
 import scala.annotation.tailrec
 import scala.util.Try
 
@@ -56,7 +58,7 @@ class VersionFilterIterator(it: RocksDBIterator, version: Option[Long]) extends 
 
 }
 
-class KeyOnlyIterator[T](underlying: RocksDBStore, startAfterKey: Option[String]) extends Iterator[String] {
+class KeyOnlyIterator[T](rawIt: RocksIterator, startAfterKey: Option[String]) extends Iterator[String] {
 
   /*
      Note that seek in the underlying iterators either hits precisely or goes to the
@@ -72,13 +74,13 @@ class KeyOnlyIterator[T](underlying: RocksDBStore, startAfterKey: Option[String]
   }
 
   override def hasNext: Boolean = {
-    val it = underlying.scanKeysOnly(compositeKeyFor(currentKey), None)
+    val it = RocksDBStore.scanKeysOnly(rawIt, compositeKeyFor(currentKey), None)
     if (it.hasNext && currentKey.isDefined && currentKey.contains(VersionedKey(it.peek).get.key)) it.next()
     it.hasNext
   }
 
   override def next(): String = {
-    val it = underlying.scanKeysOnly(compositeKeyFor(currentKey), None)
+    val it = RocksDBStore.scanKeysOnly(rawIt, compositeKeyFor(currentKey), None)
     if (it.hasNext && currentKey.isDefined && currentKey.contains(VersionedKey(it.peek).get.key)) it.next()
     val nextKey = VersionedKey(it.next()).get.key
     currentKey = Some(nextKey)
@@ -90,10 +92,20 @@ class KeyOnlyIterator[T](underlying: RocksDBStore, startAfterKey: Option[String]
 
 class VersionedKeyValueStore(underlying: RocksDBStore) {
 
-  def get(key: String, version: Option[Long] = None): Option[VersionedKeyValuePair[Array[Byte]]] =
-    scanVersionValuePairs(key, version).nextOption()
+  def withRawRocksIterator[T](block: RocksIterator => T): T = {
+    val rawIt = underlying.getRawIterator
+    val res = block(rawIt)
 
-  def getMultipleVersions(key: String, oldestVersion: Option[Long] = None, newestVersion: Option[Long] = None): (List[Array[Byte]], List[Long]) = {
+    println("close iterator")
+    rawIt.close()
+    res
+    // TODO error handling
+  }
+
+  def get(rawIt: RocksIterator, key: String, version: Option[Long] = None): Option[VersionedKeyValuePair[Array[Byte]]] =
+    scanVersionValuePairs(rawIt, key, version).nextOption()
+
+  def getMultipleVersions(rawIt: RocksIterator, key: String, oldestVersion: Option[Long] = None, newestVersion: Option[Long] = None): (List[Array[Byte]], List[Long]) = {
 
     @tailrec
     def toListIter(versionIterator: Iterator[VersionedKeyValuePair[Array[Byte]]],
@@ -106,31 +118,31 @@ class VersionedKeyValueStore(underlying: RocksDBStore) {
       }
     }
 
-    val iterator = scanVersionValuePairs(key, newestVersion)
+    val iterator = scanVersionValuePairs(rawIt, key, newestVersion)
     val (versions, keys) = toListIter(iterator, List(), List())
     (versions.reverse, keys.reverse)
   }
 
-  private def scanVersionValuePairs(key: String, version: Option[Long] = None): Iterator[VersionedKeyValuePair[Array[Byte]]] = {
+  private def scanVersionValuePairs(rawIt: RocksIterator, key: String, version: Option[Long] = None): Iterator[VersionedKeyValuePair[Array[Byte]]] = {
     requireValidKey(key)
     val prefix = s"$key${VersionedKey.versionSeparator}"
-    underlying.scan(version.map(VersionedKey(key, _).toString).getOrElse(prefix), Some(prefix)).flatMap { pair =>
+    RocksDBStore.scan(rawIt, version.map(VersionedKey(key, _).toString).getOrElse(prefix), Some(prefix)).flatMap { pair =>
       VersionedKey(pair.key).map(VersionedKeyValuePair(_, pair.value))
     }
   }
 
-  private def scanVersionsOnly(key: String, version: Option[Long] = None): Iterator[VersionedKey] = {
+  private def scanVersionsOnly(rawIt: RocksIterator, key: String, version: Option[Long] = None): Iterator[VersionedKey] = {
     requireValidKey(key)
     val prefix = s"$key${VersionedKey.versionSeparator}"
-    underlying.scanKeysOnly(version.map(VersionedKey(key, _).toString).getOrElse(prefix), Some(prefix)).flatMap { key =>
+    RocksDBStore.scanKeysOnly(rawIt, version.map(VersionedKey(key, _).toString).getOrElse(prefix), Some(prefix)).flatMap { key =>
       VersionedKey(key)
     }
   }
 
-  def getMultipleKeys(startAfterKey: Option[String], prefix: Option[String] = None, version: Option[Long] = None, limit: Option[Int]): (Seq[String], Seq[Array[Byte]], Seq[Long]) = {
+  def getMultipleKeys(rawIt: RocksIterator, startAfterKey: Option[String], prefix: Option[String] = None, version: Option[Long] = None, limit: Option[Int]): (Seq[String], Seq[Array[Byte]], Seq[Long]) = {
     startAfterKey.foreach(requireValidKey)
     prefix.foreach{ p => requireValidKey(p)}
-    val iterator: VersionFilterIterator = scanKeys(startAfterKey, prefix, version)
+    val iterator: VersionFilterIterator = scanKeys(rawIt, startAfterKey, prefix, version)
 
     /*
        Note that seek in the underlying iterators either hits precisely or goes to the
@@ -155,12 +167,12 @@ class VersionedKeyValueStore(underlying: RocksDBStore) {
     (keys, values, versions)
   }
 
-  private def scanKeys(startAfterKey: Option[String], prefix: Option[String] = None, version: Option[Long] = None): VersionFilterIterator = {
+  private def scanKeys(rawIt: RocksIterator, startAfterKey: Option[String], prefix: Option[String] = None, version: Option[Long] = None): VersionFilterIterator = {
     val fullKey = startAfterKey.map(key => s"$key${VersionedKey.versionSeparator}").orElse(prefix).getOrElse("")
-    new VersionFilterIterator(underlying.scan(fullKey, prefix), version)
+    new VersionFilterIterator(RocksDBStore.scan(rawIt, fullKey, prefix), version)
   }
 
-  def deleteMultipleVersions(key: String, oldestVersion: Option[Long] = None, newestVersion: Option[Long] = None): Unit = {
+  def deleteMultipleVersions(rawIt: RocksIterator, key: String, oldestVersion: Option[Long] = None, newestVersion: Option[Long] = None): Unit = {
     @tailrec
     def deleteIter(versionIterator: Iterator[VersionedKey]): Unit = {
       if (versionIterator.hasNext) {
@@ -172,7 +184,7 @@ class VersionedKeyValueStore(underlying: RocksDBStore) {
       }
     }
 
-    val versionsIterator = scanVersionsOnly(key, newestVersion)
+    val versionsIterator = scanVersionsOnly(rawIt, key, newestVersion)
     deleteIter(versionsIterator)
   }
 
@@ -186,13 +198,13 @@ class VersionedKeyValueStore(underlying: RocksDBStore) {
     underlying.delete(VersionedKey(key, version).toString)
   }
 
-  def listKeys(limit: Option[Int], startAfterKey: Option[String]): Seq[String] = {
-    val iterator = new KeyOnlyIterator(underlying, startAfterKey)
+  def listKeys(rawIt: RocksIterator, limit: Option[Int], startAfterKey: Option[String]): Seq[String] = {
+    val iterator = new KeyOnlyIterator(rawIt, startAfterKey)
     iterator.take(limit.getOrElse(Int.MaxValue)).toSeq
   }
 
-  def listVersions(key: String, limit: Option[Int], offset: Option[Int]): Seq[Long] = {
-    val iterator = scanVersionsOnly(key)
+  def listVersions(rawIt: RocksIterator, key: String, limit: Option[Int], offset: Option[Int]): Seq[Long] = {
+    val iterator = scanVersionsOnly(rawIt, key)
     iterator.map(_.version).drop(offset.getOrElse(0)).take(limit.getOrElse(Int.MaxValue)).toSeq
   }
 

--- a/src/main/scala/com/scalableminds/fossildb/db/VersionedKeyValueStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/VersionedKeyValueStore.scala
@@ -92,15 +92,7 @@ class KeyOnlyIterator[T](rawIt: RocksIterator, startAfterKey: Option[String]) ex
 
 class VersionedKeyValueStore(underlying: RocksDBStore) {
 
-  def withRawRocksIterator[T](block: RocksIterator => T): T = {
-    val rawIt = underlying.getRawIterator
-    val res = block(rawIt)
-
-    println("close iterator")
-    rawIt.close()
-    res
-    // TODO error handling
-  }
+  def withRawRocksIterator[T](block: RocksIterator => T): T = underlying.withRawRocksIterator(block)
 
   def get(rawIt: RocksIterator, key: String, version: Option[Long] = None): Option[VersionedKeyValuePair[Array[Byte]]] =
     scanVersionValuePairs(rawIt, key, version).nextOption()


### PR DESCRIPTION
The caller should close the Iterator returned by `RocksDB.newIterator`. That’s us.

I ran this stress test
```
    for i in range(100000):
        reply = stub.ListVersions(proto.ListVersionsRequest(collection=collection, key=volume_id))
        assert_success(reply)
```
and on master, fossilDB memory usage went up by about 1.5 GB for each run. On this branch, it stayed steady even after multiple runs. Speed seems unaffected (variations are smaller than noise)