### PR TITLE
Add DeleteAllByPrefix and PutMultipleVersions API endpoints

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Added
+ - New API endpoints `DeleteAllByPrefix` and `PutMultipleVersions`. [#47](https://github.com/scalableminds/fossildb/pull/47)
+
 ## Breaking Changes
 
  - The `GetMultipleKeys` call now takes a `startAfterKey` instead of a `key` for pagination. The returned list will only start *after* this key. [#38](https://github.com/scalableminds/fossildb/pull/38)

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ version := getVersionFromGit
 scalaVersion := "2.13.12"
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.4.7",
+  "ch.qos.logback" % "logback-classic" % "1.5.6",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-  "org.scalatest" % "scalatest_2.13" % "3.2.15" % "test",
+  "org.scalatest" % "scalatest_2.13" % "3.2.19" % "test",
   "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion,
   "io.grpc" % "grpc-services" % scalapb.compiler.Version.grpcJavaVersion,
   "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,

--- a/src/main/protobuf/fossildbapi.proto
+++ b/src/main/protobuf/fossildbapi.proto
@@ -34,6 +34,18 @@ message PutReply {
     optional string errorMessage = 2;
 }
 
+message PutMultipleVersionsRequest {
+    required string collection = 1;
+    required string key = 2;
+    repeated uint64 versions = 3;
+    repeated bytes values = 4;
+}
+
+message PutMultipleVersionsReply {
+    required bool success = 1;
+    optional string errorMessage = 2;
+}
+
 message DeleteRequest {
     required string collection = 1;
     required string key = 2;
@@ -164,6 +176,7 @@ service FossilDB {
     rpc GetMultipleVersions (GetMultipleVersionsRequest) returns (GetMultipleVersionsReply) {}
     rpc GetMultipleKeys (GetMultipleKeysRequest) returns (GetMultipleKeysReply) {}
     rpc Put (PutRequest) returns (PutReply) {}
+    rpc PutMultipleVersions (PutMultipleVersionsRequest) returns (PutMultipleVersionsReply) {}
     rpc Delete (DeleteRequest) returns (DeleteReply) {}
     rpc DeleteMultipleVersions (DeleteMultipleVersionsRequest) returns (DeleteMultipleVersionsReply) {}
     rpc DeleteAllByPrefix (DeleteAllByPrefixRequest) returns (DeleteAllByPrefixReply) {}

--- a/src/main/protobuf/fossildbapi.proto
+++ b/src/main/protobuf/fossildbapi.proto
@@ -45,6 +45,16 @@ message DeleteReply {
     optional string errorMessage = 2;
 }
 
+message DeleteAllByPrefixRequest {
+    required string collection = 1;
+    required string prefix = 2;
+}
+
+message DeleteAllByPrefixReply {
+    required bool success = 1;
+    optional string errorMessage = 2;
+}
+
 message GetMultipleVersionsRequest {
     required string collection = 1;
     required string key = 2;
@@ -156,6 +166,7 @@ service FossilDB {
     rpc Put (PutRequest) returns (PutReply) {}
     rpc Delete (DeleteRequest) returns (DeleteReply) {}
     rpc DeleteMultipleVersions (DeleteMultipleVersionsRequest) returns (DeleteMultipleVersionsReply) {}
+    rpc DeleteAllByPrefix (DeleteAllByPrefixRequest) returns (DeleteAllByPrefixReply) {}
     rpc ListKeys (ListKeysRequest) returns (ListKeysReply) {}
     rpc ListVersions (ListVersionsRequest) returns (ListVersionsReply) {}
     rpc Backup (BackupRequest) returns (BackupReply) {}

--- a/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
+++ b/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
@@ -60,6 +60,12 @@ class FossilDBGrpcImpl(storeManager: StoreManager)
     DeleteMultipleVersionsReply(success = true)
   } { errorMsg => DeleteMultipleVersionsReply(success = false, errorMsg) }
 
+  override def deleteAllByPrefix(req: DeleteAllByPrefixRequest): Future[DeleteAllByPrefixReply] = withExceptionHandler(req) {
+    val store = storeManager.getStore(req.collection)
+    store.withRawRocksIterator{rocksIt => store.deleteAllByPrefix(rocksIt, req.prefix)}
+    DeleteAllByPrefixReply(success = true)
+  } { errorMsg => DeleteAllByPrefixReply(success = false, errorMsg)}
+
   override def listKeys(req: ListKeysRequest): Future[ListKeysReply] = withExceptionHandler(req) {
     val store = storeManager.getStore(req.collection)
     val keys = store.withRawRocksIterator{rocksIt => store.listKeys(rocksIt, req.limit, req.startAfterKey)}

--- a/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/RocksDBStore.scala
@@ -36,7 +36,6 @@ class RocksDBManager(dataDir: Path, columnFamilies: List[String], optionsFilePat
     }
     options.setCreateIfMissing(true).setCreateMissingColumnFamilies(true)
     val defaultColumnFamilyOptions: ColumnFamilyOptions = cfListRef.find(_.getName sameElements RocksDB.DEFAULT_COLUMN_FAMILY).map(_.getOptions).getOrElse(columnOptions)
-    println(defaultColumnFamilyOptions)
     val newColumnFamilyDescriptors = (columnFamilies.map(_.getBytes) :+ RocksDB.DEFAULT_COLUMN_FAMILY).diff(cfListRef.toList.map(_.getName)).map(new ColumnFamilyDescriptor(_, defaultColumnFamilyOptions))
     val columnFamilyDescriptors = cfListRef.toList ::: newColumnFamilyDescriptors
     logger.info("Opening RocksDB at " + dataDir.toAbsolutePath)

--- a/src/main/scala/com/scalableminds/fossildb/db/VersionedKeyValueStore.scala
+++ b/src/main/scala/com/scalableminds/fossildb/db/VersionedKeyValueStore.scala
@@ -180,6 +180,10 @@ class VersionedKeyValueStore(underlying: RocksDBStore) {
     deleteIter(versionsIterator)
   }
 
+  def deleteAllByPrefix(rocksIt: RocksIterator, prefix: String): Unit = {
+    RocksDBStore.scanKeysOnly(rocksIt, prefix, Some(prefix)).foreach(underlying.delete)
+  }
+
   def put(key: String, version: Long, value: Array[Byte]): Unit = {
     requireValidKey(key)
     underlying.put(VersionedKey(key, version).toString, value)

--- a/src/test/scala/com/scalableminds/fossildb/FossilDBSuite.scala
+++ b/src/test/scala/com/scalableminds/fossildb/FossilDBSuite.scala
@@ -134,6 +134,21 @@ class FossilDBSuite extends AnyFlatSpec with BeforeAndAfterEach with TestHelpers
     assert(testData1 == reply.value)
   }
 
+  "DeleteAllByPrefix" should "delete all versions of all values matching this prefix" in {
+    client.put(PutRequest(collectionA, "prefixedA", Some(0), testData1))
+    client.put(PutRequest(collectionA, "prefixedA", Some(1), testData1))
+    client.put(PutRequest(collectionA, "prefixedB", Some(0), testData2))
+    client.put(PutRequest(collectionA, "prefixedC", Some(0), testData2))
+    client.put(PutRequest(collectionA, "differentKey", Some(0), testData2))
+    client.put(PutRequest(collectionA, "differentKey", Some(1), testData2))
+    client.put(PutRequest(collectionA, "yetDifferentKey", Some(0), testData2))
+    client.deleteAllByPrefix(DeleteAllByPrefixRequest(collectionA, "prefixed"))
+    val reply = client.listKeys(ListKeysRequest(collectionA))
+    assert(reply.keys.length == 2)
+    assert(reply.keys.contains("differentKey"))
+    assert(reply.keys.contains("yetDifferentKey"))
+  }
+
   "ListKeys" should "list all keys of a collection" in {
     client.put(PutRequest(collectionA, aKey, Some(0), testData1))
     client.put(PutRequest(collectionA, aKey, Some(1), testData2))

--- a/src/test/scala/com/scalableminds/fossildb/FossilDBSuite.scala
+++ b/src/test/scala/com/scalableminds/fossildb/FossilDBSuite.scala
@@ -69,6 +69,16 @@ class FossilDBSuite extends AnyFlatSpec with BeforeAndAfterEach with TestHelpers
     assert(testData2 == reply.value)
   }
 
+  "PutMultipleVersions" should "overwrite old values, leave others untouched" in {
+    client.put(PutRequest(collectionA, aKey, Some(0), testData1))
+    client.put(PutRequest(collectionA, aKey, Some(2), testData1))
+    client.putMultipleVersions(PutMultipleVersionsRequest(collectionA, aKey, Seq(1,2,3), Seq(testData2, testData3, testData3)))
+    val reply = client.getMultipleVersions(GetMultipleVersionsRequest(collectionA, aKey))
+    assert(reply.values.length == 4)
+    assert(reply.versions == Seq(3,2,1,0))
+    assert(reply.values == Seq(testData3, testData3, testData2, testData1))
+  }
+
   it should "fail on non-existent collection" in {
     val reply = client.put(PutRequest("nonExistentCollection", aKey, Some(0), testData1))
     assert(!reply.success)


### PR DESCRIPTION
Needed for the migration of https://github.com/scalableminds/webknossos/pull/7917

Adds two new API endpoints

 - [x] DeleteAllByPrefix
 - [x] PutMultipleVersions

And corresponding tests.

This is not exactly what #39 is about, but it goes in a similar direction.

Note that I did not make use of RocksDB transaction management here yet, for the sake of simplicity and the reasons discussed in https://github.com/scalableminds/fossildb/issues/39#issuecomment-1587142873