### PR TITLE
Skip empty entries in getMultipleKeysByListWithMultipleVersions response

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,3 +13,4 @@
 ## Fixes
 
  - Fixed a bug where the pagination for `GetMultipleKeys` could lead to an endless loop if some keys are prefixes of others. [#38](https://github.com/scalableminds/fossildb/pull/38)
+ - Empty entries are now removed in the response of `GetMultipleKeysByListWithMultipleVersions`. Those could previously occur if no versions matched the requested range. [#51](https://github.com/scalableminds/fossildb/pull/51)

--- a/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
+++ b/src/main/scala/com/scalableminds/fossildb/FossilDBGrpcImpl.scala
@@ -72,7 +72,7 @@ class FossilDBGrpcImpl(storeManager: StoreManager)
         VersionValuePairProto(version, ByteString.copyFrom(value))
       }
       KeyVersionsValuesPairProto(key, versionValuePairs)
-    }
+    }.filter(_.versionValuePairs.nonEmpty)
     GetMultipleKeysByListWithMultipleVersionsReply(success = true, None, keyVersionsValuesPairs)
   } { errorMsg => GetMultipleKeysByListWithMultipleVersionsReply(success = false, errorMsg) }
 

--- a/src/test/scala/com/scalableminds/fossildb/FossilDBSuite.scala
+++ b/src/test/scala/com/scalableminds/fossildb/FossilDBSuite.scala
@@ -430,6 +430,17 @@ class FossilDBSuite extends AnyFlatSpec with BeforeAndAfterEach with TestHelpers
     assert(reply.keyVersionsValuesPairs(1).versionValuePairs(0) == VersionValuePairProto(1L, testData2))
   }
 
+  it should "return an empty list if no versions match" in {
+    client.put(PutRequest(collectionA, aKey, Some(0), testData1))
+    client.put(PutRequest(collectionA, aNotherKey, Some(0), testData1))
+    client.put(PutRequest(collectionA, aKey, Some(1), testData2))
+    client.put(PutRequest(collectionA, aNotherKey, Some(1), testData2))
+    client.put(PutRequest(collectionA, aKey, Some(5), testData3))
+    client.put(PutRequest(collectionA, aNotherKey, Some(5), testData3))
+    val reply = client.getMultipleKeysByListWithMultipleVersions(GetMultipleKeysByListWithMultipleVersionsRequest(collectionA, keys = Seq(aNotherKey, aThirdKey, aThirdKey), newestVersion = Some(3), oldestVersion = Some(4)))
+    assert(reply.keyVersionsValuesPairs.isEmpty)
+  }
+
   "Backup" should "create non-empty backup directory" in {
     client.put(PutRequest(collectionA, aKey, Some(0), testData1))
     client.backup(BackupRequest())


### PR DESCRIPTION
Skip empty entries in getMultipleKeysByListWithMultipleVersions response. Those can arise if no versions match the specified range.