### PR TITLE
Add new api call GetMultipleKeysByList

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
  - New API endpoints `DeleteAllByPrefix` and `PutMultipleVersions`. [#47](https://github.com/scalableminds/fossildb/pull/47)
  - New API endpoints `GetMultipleKeysByListWithMultipleVersions` and `PutMultipleKeysWithMultipleVersions` for reading and writing multiple keys/versions in one request. [#48](https://github.com/scalableminds/fossildb/pull/48)
  - `ListKeys` now supports optional `prefix` field
+ - New API endpoint `GetMultipleKeysByList`. [#52](https://github.com/scalableminds/fossildb/pull/52)
 
 ## Breaking Changes
 

--- a/src/main/protobuf/fossildbapi.proto
+++ b/src/main/protobuf/fossildbapi.proto
@@ -18,6 +18,11 @@ message VersionValuePairProto {
     required bytes value = 2;
 }
 
+message VersionValueBoxProto {
+    optional VersionValuePairProto versionValuePair = 1;
+    optional string errorMessage = 2;
+}
+
 message HealthRequest {}
 message HealthReply {
     required bool success = 1;
@@ -123,6 +128,18 @@ message GetMultipleKeysReply {
     repeated uint64 actualVersions = 5;
 }
 
+message GetMultipleKeysByListRequest {
+    required string collection = 1;
+    repeated string keys = 2;
+    optional uint64 version = 3; // Applied to all requested keys
+}
+
+message GetMultipleKeysByListReply {
+    required bool success = 1;
+    optional string errorMessage = 2;
+    repeated VersionValueBoxProto versionValueBoxes = 3;
+}
+
 message GetMultipleKeysByListWithMultipleVersionsRequest {
     required string collection = 1;
     repeated string keys = 2;
@@ -215,6 +232,7 @@ service FossilDB {
     rpc Get (GetRequest) returns (GetReply) {}
     rpc GetMultipleVersions (GetMultipleVersionsRequest) returns (GetMultipleVersionsReply) {}
     rpc GetMultipleKeys (GetMultipleKeysRequest) returns (GetMultipleKeysReply) {}
+    rpc GetMultipleKeysByList (GetMultipleKeysByListRequest) returns (GetMultipleKeysByListReply) {}
     rpc GetMultipleKeysByListWithMultipleVersions (GetMultipleKeysByListWithMultipleVersionsRequest) returns (GetMultipleKeysByListWithMultipleVersionsReply) {}
     rpc Put (PutRequest) returns (PutReply) {}
     rpc PutMultipleVersions (PutMultipleVersionsRequest) returns (PutMultipleVersionsReply) {}


### PR DESCRIPTION
GetMultipleKeysByList differs from the existing GetMultipleKeysByListWithMultipleVersion in that you specify a single optional version, and a single version is returned.

Also, missing elements will not be skipped but encoded as empty in the response.

### TODO
 - [x] changelog
 - [x] unit tests